### PR TITLE
Explicit receive send buffers

### DIFF
--- a/EasySockets/EasySockets/Builder/EasySocketOptions.cs
+++ b/EasySockets/EasySockets/Builder/EasySocketOptions.cs
@@ -10,21 +10,58 @@ public sealed class EasySocketOptions
     private string _closingStatusDescription = "Closing";
 
     private Encoding _encoding = Encoding.UTF8;
+    private int _receiveBufferSize = 100;
+    private int _sendBufferSize = 100;
     internal List<Type> Authenticators { get; set; } = new();
 
     /// <summary>
-    ///     The size of chunks when receiving messages. <br /><br />
-    ///     Increasing this will allocate more memory for each message received and sent.
-    ///     Decreasing this will cause receiving the full message to take more time.<br /><br />
+    ///     The size of chunks when receiving or sending messages. <br />
     ///     Default is 100 bytes (100B).
     /// </summary>
+    [Obsolete($"Use {nameof(ReceiveBufferSize)} and {nameof(SendBufferSize)} instead")]
     public int BufferSize
     {
         get => _bufferSize;
         set
         {
-            if (value < 1) throw new ArgumentOutOfRangeException(nameof(value), "Chunk size cannot be less than 1");
+            if (value < 1)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(BufferSize)} cannot be less than 1");
             _bufferSize = value;
+            _receiveBufferSize = value;
+            _sendBufferSize = value;
+        }
+    }
+
+    /// <summary>
+    ///     The size of the byte array used to receive messages.<br />
+    ///     When expecting to receive large messages, it is recommended to increase this value.<br />
+    ///     Default is 100 bytes (100B).
+    /// </summary>
+    public int ReceiveBufferSize
+    {
+        get => _receiveBufferSize;
+        set
+        {
+            if (value < 1)
+                throw new ArgumentOutOfRangeException(nameof(value),
+                    $"{nameof(ReceiveBufferSize)} cannot be less than 1");
+            _receiveBufferSize = value;
+        }
+    }
+
+    /// <summary>
+    ///     The size of the byte array used to send messages.<br />
+    ///     When expecting to send large messages back to the client, it is recommended to increase this value.<br />
+    ///     Default is 100 bytes (100B).
+    /// </summary>
+    public int SendBufferSize
+    {
+        get => _sendBufferSize;
+        set
+        {
+            if (value < 1)
+                throw new ArgumentOutOfRangeException(nameof(value), $"{nameof(SendBufferSize)} cannot be less than 1");
+            _sendBufferSize = value;
         }
     }
 

--- a/EasySockets/EasySockets/Builder/EasySocketOptions.cs
+++ b/EasySockets/EasySockets/Builder/EasySocketOptions.cs
@@ -18,7 +18,7 @@ public sealed class EasySocketOptions
     ///     The size of chunks when receiving or sending messages. <br />
     ///     Default is 100 bytes (100B).
     /// </summary>
-    [Obsolete($"Use {nameof(ReceiveBufferSize)} and {nameof(SendBufferSize)} instead")]
+    [Obsolete($"Use {nameof(ReceiveBufferSize)} and {nameof(SendBufferSize)} instead. This property will be removed in future versions.")]
     public int BufferSize
     {
         get => _bufferSize;

--- a/EasySockets/EasySockets/EasySocket.cs
+++ b/EasySockets/EasySockets/EasySocket.cs
@@ -16,7 +16,7 @@ public abstract class EasySocket : IEasySocket
     private bool _isDisposed;
     private bool _isReceiving;
     private bool _isSending;
-    private byte[] _byteBuffer = Array.Empty<byte>();
+    private byte[] _sendBuffer = Array.Empty<byte>();
     private int _bufferCharCount;
 
     string IInternalEasySocket.RoomId
@@ -39,7 +39,7 @@ public abstract class EasySocket : IEasySocket
         set
         {
             _options = value;
-            _byteBuffer = new byte[_options.SendBufferSize];
+            _sendBuffer = new byte[_options.SendBufferSize];
             _bufferCharCount = _options.Encoding.GetMaxCharCount(_options.SendBufferSize);
         }
     }
@@ -170,11 +170,11 @@ public abstract class EasySocket : IEasySocket
                 while (charsProcessed < message.Length)
                 {
                     var flush = charsProcessed + _bufferCharCount >= message.Length;
-                    encoder.Convert(message.AsSpan()[charsProcessed..], _byteBuffer, flush, out var charsUsed,
+                    encoder.Convert(message.AsSpan()[charsProcessed..], _sendBuffer, flush, out var charsUsed,
                         out var bytesUsed, out _);
 
                     await _webSocket
-                        .SendAsync(new ArraySegment<byte>(_byteBuffer, 0, bytesUsed), WebSocketMessageType.Text, flush,
+                        .SendAsync(new ArraySegment<byte>(_sendBuffer, 0, bytesUsed), WebSocketMessageType.Text, flush,
                             _cts.Token)
                         .ConfigureAwait(false);
 

--- a/EasySockets/EasySockets/EasySocket.cs
+++ b/EasySockets/EasySockets/EasySocket.cs
@@ -39,8 +39,8 @@ public abstract class EasySocket : IEasySocket
         set
         {
             _options = value;
-            _byteBuffer = new byte[_options.BufferSize];
-            _bufferCharCount = _options.Encoding.GetMaxCharCount(_options.BufferSize);
+            _byteBuffer = new byte[_options.SendBufferSize];
+            _bufferCharCount = _options.Encoding.GetMaxCharCount(_options.SendBufferSize);
         }
     }
 
@@ -104,7 +104,7 @@ public abstract class EasySocket : IEasySocket
         _isReceiving = true;
 
         StringBuilder sb = new();
-        var buffer = new byte[_options.BufferSize];
+        var buffer = new byte[_options.ReceiveBufferSize];
 
         while (IsConnected() && !_cts.IsCancellationRequested && !_isDisposed)
         {

--- a/EasySockets/EasySocketsTests/Builder/EasySocketOptionsTests.cs
+++ b/EasySockets/EasySocketsTests/Builder/EasySocketOptionsTests.cs
@@ -10,7 +10,7 @@ public class EasySocketOptionsTests
 	[Theory]
 	[InlineData(-1)]
 	[InlineData(0)]
-	public void ChunkSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int chunkSize)
+	public void BufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int chunkSize)
 	{
 		// Arrange
 		var options = new EasySocketOptions();
@@ -21,7 +21,7 @@ public class EasySocketOptionsTests
     }
 
     [Fact]
-	public void PropertySetters_WhenSetToNull_ShouldThrowArgumentNullException()
+	public void EncodingSetter_WhenSetToNull_ShouldThrowArgumentNullException()
 	{
         // Arrange
         EasySocketOptions options = new();
@@ -36,7 +36,7 @@ public class EasySocketOptionsTests
 	[InlineData(100)]
 	[InlineData(1000)]
 	[InlineData(int.MaxValue)]
-	public void ChunkSizeSetter_WhenSetToValidValue_ShouldUpdateValue(int chunkSize)
+	public void BufferSizeSetter_WhenSetToValidValue_ShouldUpdateValue(int chunkSize)
 	{
         // Arrange
         EasySocketOptions options = new();
@@ -47,6 +47,64 @@ public class EasySocketOptionsTests
 		// Assert
         Assert.Equal(chunkSize, options.BufferSize);
 	}
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+    public void ReceiveBufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int value)
+    {
+        // Arrange
+        var options = new EasySocketOptions();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.ReceiveBufferSize = value);
+    }
+
+	[Theory]
+	[InlineData(0)]
+	[InlineData(-1)]
+	public void SendBufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int value)
+    {
+        // Arrange
+        var options = new EasySocketOptions();
+
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.SendBufferSize = value);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(int.MaxValue)]
+    public void ReceiveBufferSizeSetter_WhenSetToValidValue_ShouldUpdateValue(int value)
+    {
+        // Arrange
+        EasySocketOptions options = new();
+
+        // Act
+        options.ReceiveBufferSize = value;
+
+        // Assert
+        Assert.Equal(value, options.ReceiveBufferSize);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(int.MaxValue)]
+    public void SendBufferSizeSetter_WhenSetToValidValue_ShouldUpdateValue(int value)
+    {
+        // Arrange
+        EasySocketOptions options = new();
+
+        // Act
+        options.SendBufferSize = value;
+
+        // Assert
+        Assert.Equal(value, options.SendBufferSize);
+    }
 
 	[Fact]
 	public void EncodingSetter_WhenSetToValidValue_ShouldUpdateValue()

--- a/EasySockets/EasySocketsTests/Builder/EasySocketOptionsTests.cs
+++ b/EasySockets/EasySocketsTests/Builder/EasySocketOptionsTests.cs
@@ -1,4 +1,5 @@
 ﻿// ReSharper disable UseObjectOrCollectionInitializer : Unnecessary in this case, as it divides the arrange/act/assert sections of the tests
+
 #pragma warning disable IDE0017
 
 using System.Text;
@@ -7,50 +8,50 @@ namespace EasySockets.Builder;
 
 public class EasySocketOptionsTests
 {
-	[Theory]
-	[InlineData(-1)]
-	[InlineData(0)]
-	public void BufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int chunkSize)
-	{
-		// Arrange
-		var options = new EasySocketOptions();
+    [Theory]
+    [InlineData(-1)]
+    [InlineData(0)]
+    public void BufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int chunkSize)
+    {
+        // Arrange
+        var options = new EasySocketOptions();
 
-		// Act & Assert
-		Assert.Throws<ArgumentOutOfRangeException>(() => options.BufferSize = chunkSize);
+        // Act & Assert
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.BufferSize = chunkSize);
         Assert.Throws<ArgumentOutOfRangeException>(() => options.BufferSize = chunkSize);
     }
 
     [Fact]
-	public void EncodingSetter_WhenSetToNull_ShouldThrowArgumentNullException()
-	{
+    public void PropertySetter_WhenSetToNull_ShouldThrowArgumentNullException()
+    {
         // Arrange
         EasySocketOptions options = new();
 
-		// Act & Assert
-		Assert.Throws<ArgumentNullException>(() => options.Encoding = null!);
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => options.Encoding = null!);
         Assert.Throws<ArgumentNullException>(() => options.ClosingStatusDescription = null!);
     }
 
-	[Theory]
-	[InlineData(1)]
-	[InlineData(100)]
-	[InlineData(1000)]
-	[InlineData(int.MaxValue)]
-	public void BufferSizeSetter_WhenSetToValidValue_ShouldUpdateValue(int chunkSize)
-	{
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(1000)]
+    [InlineData(int.MaxValue)]
+    public void BufferSizeSetter_WhenSetToValidValue_ShouldUpdateValue(int chunkSize)
+    {
         // Arrange
         EasySocketOptions options = new();
 
         // Act
-		options.BufferSize = chunkSize;
+        options.BufferSize = chunkSize;
 
-		// Assert
+        // Assert
         Assert.Equal(chunkSize, options.BufferSize);
-	}
+    }
 
-	[Theory]
-	[InlineData(0)]
-	[InlineData(-1)]
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
     public void ReceiveBufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int value)
     {
         // Arrange
@@ -60,10 +61,10 @@ public class EasySocketOptionsTests
         Assert.Throws<ArgumentOutOfRangeException>(() => options.ReceiveBufferSize = value);
     }
 
-	[Theory]
-	[InlineData(0)]
-	[InlineData(-1)]
-	public void SendBufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int value)
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void SendBufferSizeSetter_IfLowerThanOne_ShouldThrowArgumentOutOfRangeException(int value)
     {
         // Arrange
         var options = new EasySocketOptions();
@@ -106,29 +107,29 @@ public class EasySocketOptionsTests
         Assert.Equal(value, options.SendBufferSize);
     }
 
-	[Fact]
-	public void EncodingSetter_WhenSetToValidValue_ShouldUpdateValue()
-	{
+    [Fact]
+    public void EncodingSetter_WhenSetToValidValue_ShouldUpdateValue()
+    {
         // Arrange
         EasySocketOptions options = new();
 
-		// Act
-		options.Encoding = Encoding.ASCII;
+        // Act
+        options.Encoding = Encoding.ASCII;
 
-		// Assert
-		Assert.Equal(Encoding.ASCII, options.Encoding);
-	}
+        // Assert
+        Assert.Equal(Encoding.ASCII, options.Encoding);
+    }
 
-	[Fact]
-	public void ClosingStatusDescriptionSetter_WhenSetToValidValue_ShouldUpdateValue()
-	{
+    [Fact]
+    public void ClosingStatusDescriptionSetter_WhenSetToValidValue_ShouldUpdateValue()
+    {
         // Arrange
         EasySocketOptions options = new();
 
-		// Act
+        // Act
         options.ClosingStatusDescription = "Test";
 
-		// Assert
-		Assert.Equal("Test", options.ClosingStatusDescription);
-	}
+        // Assert
+        Assert.Equal("Test", options.ClosingStatusDescription);
+    }
 }


### PR DESCRIPTION
Let the user explicitly define the receive and send buffer sizes to optimize their application further.